### PR TITLE
Draft: Add dragonflight support

### DIFF
--- a/Data.lua
+++ b/Data.lua
@@ -61,11 +61,9 @@ RaidSkipper.raid_skip_quests = {
     {
         name = "Dragonflight",
         raids = {
-            -- instanceId is not correct, I do know which ID should be used.
-            { name = "Vault of the Incarnates", instanceId = 2296, mythicId = 71020, heroicId = 71019, normalId = 71018 },
-            -- instanceId is not correct, I do know which ID should be used.
+            { name = "Vault of the Incarnates", instanceId = 14030, mythicId = 71020, heroicId = 71019, normalId = 71018 },
             -- Aberrus seems to only have a heroic and mythic quest, no normal quest https://www.wowhead.com/zone=14663/aberrus-the-shadowed-crucible#quests
-            { name = "Aberrus, the Shadowed Crucible", instanceId = 2296, mythicId = 76086, heroicId = 76085 },
+            { name = "Aberrus, the Shadowed Crucible", instanceId = 14663, mythicId = 76086, heroicId = 76085, normalId = 76083 },
         }
     }
 }

--- a/Data.lua
+++ b/Data.lua
@@ -4,7 +4,7 @@ RaidSkipper.raid_skip_quests = {
     {
         name = "Warlords of Draenor",
         raids = {
-            { name = "Blackrock Foundary", instanceId = 1205,  mythicId = 37031, heroicId = 37030, normalId = 37029 },
+            { name = "Blackrock Foundary",     instanceId = 1205, mythicId = 37031, heroicId = 37030, normalId = 37029 },
             { name = "Hellfire Citadel Lower", instanceId = 1448, mythicId = 39501, heroicId = 39500, normalId = 39499 },
             { name = "Hellfire Citadel Upper", instanceId = 1448, mythicId = 39505, heroicId = 39504, normalId = 39502 }
         }
@@ -13,25 +13,57 @@ RaidSkipper.raid_skip_quests = {
         name = "Legion",
         raids = {
             { name = "The Emerald Nightmare", instanceId = 1520, mythicId = 44285, heroicId = 44284, normalId = 44283 },
-            { name = "The Nighthold", instanceId = 1530, mythicId = 45383, heroicId = 45382, normalId = 45381 },
-            { name = "Tomb of Sargeras", instanceId = 1676, mythicId = 47727, heroicId = 47726, normalId = 47725 },
-            { name = "Burning Throne Lower", instanceId = 1712, mythicId = 49076, heroicId = 49075, normalId = 49032 },
-            { name = "Burning Throne Upper", instanceId = 1712, mythicId = 49135, heroicId = 49134, normalId = 49133 }
+            { name = "The Nighthold",         instanceId = 1530, mythicId = 45383, heroicId = 45382, normalId = 45381 },
+            { name = "Tomb of Sargeras",      instanceId = 1676, mythicId = 47727, heroicId = 47726, normalId = 47725 },
+            { name = "Burning Throne Lower",  instanceId = 1712, mythicId = 49076, heroicId = 49075, normalId = 49032 },
+            { name = "Burning Throne Upper",  instanceId = 1712, mythicId = 49135, heroicId = 49134, normalId = 49133 }
         }
     },
     {
         name = "Battle for Azeroth",
         raids = {
             { name = "Battle of Dazar'alor", instanceId = 2070, achievementId = 13314, mythicId = 316476 },
-            { name = "Ny'alotha, the Waking City", instanceId = 2217, mythicId = 58375, heroicId = 58374, normalId = 58373 }
+            {
+                name = "Ny'alotha, the Waking City",
+                instanceId = 2217,
+                mythicId = 58375,
+                heroicId = 58374,
+                normalId = 58373
+            }
         }
     },
     {
         name = "Shadowlands",
         raids = {
-            { name = "Castle Nathria", instanceId = 2296, mythicId = 62056, heroicId = 62055, normalId = 62054 },
-            { name = "Sanctum of Domination", instanceId = 2450, mythicId = 64599, heroicId = 64598, normalId = 64597 },
-            { name = "Sepulcher of the First Ones", instanceId = 2481, mythicId = 65762, heroicId = 65763, normalId = 65764 }
+            {
+                name = "Castle Nathria",
+                instanceId = 2296,
+                mythicId = 62056,
+                heroicId = 62055,
+                normalId = 62054
+            },
+            {
+                name = "Sanctum of Domination",
+                instanceId = 2450,
+                mythicId = 64599,
+                heroicId = 64598,
+                normalId = 64597
+            },
+            {
+                name = "Sepulcher of the First Ones",
+                instanceId = 2481,
+                mythicId = 65762,
+                heroicId = 65763,
+                normalId = 65764
+            }
+        }
+    },
+    {
+        name = "Dragonflight",
+        raids = {
+            -- instanceId is not correct, I do know which ID should be used.
+            { name = "Vault of the Incarnates", instanceId = 2296, mythicId = 71020, heroicId = 71019, normalId = 71018 },
         }
     }
 }
+

--- a/Data.lua
+++ b/Data.lua
@@ -63,6 +63,9 @@ RaidSkipper.raid_skip_quests = {
         raids = {
             -- instanceId is not correct, I do know which ID should be used.
             { name = "Vault of the Incarnates", instanceId = 2296, mythicId = 71020, heroicId = 71019, normalId = 71018 },
+            -- instanceId is not correct, I do know which ID should be used.
+            -- Aberrus seems to only have a heroic and mythic quest, no normal quest https://www.wowhead.com/zone=14663/aberrus-the-shadowed-crucible#quests
+            { name = "Aberrus, the Shadowed Crucible", instanceId = 2296, mythicId = 76086, heroicId = 76085 },
         }
     }
 }

--- a/RaidSkipper.lua
+++ b/RaidSkipper.lua
@@ -135,6 +135,7 @@ local function PrintHelp()
     RaidSkipper:Print("  /rs legion --> Legion")
     RaidSkipper:Print("  /rs bfa --> Battle for Azeroth")
     RaidSkipper:Print("  /rs sl --> Shadowlands")
+    RaidSkipper:Print("  /rs df --> Dragonflight")
 end
 
 local function ShowRaidInstanceById(id)
@@ -298,7 +299,9 @@ function SlashHandler(args)
             ShowExpansion(RaidSkipper.raid_skip_quests[3])
         elseif arg1 == "sl" then
             ShowExpansion(RaidSkipper.raid_skip_quests[4])
-        elseif arg1 == "korthia" then
+        elseif arg1 == "df" then
+            ShowExpansion(RaidSkipper.raid_skip_quests[5])
+       elseif arg1 == "korthia" then
             ShowKorthiaDailyCaps()
         else
             PrintHelp()


### PR DESCRIPTION
Hi,

Did not wait your answer to make a PR, as I liked the exercise (never coded a wow addon). Feel free to reject it if you do not want any contribution.

This is only a draft, as the following items need to be taken care of:
- Both VOTI and Aberrus `instanceId` are wrong. Could not find what was the ID that you used on the other instance. Only found `zoneId` on wowhead, but did not match with the one you had for previous raid.
- Aberrus seems to only have two skip quests (the normal skip seems to be unavailable) [source](https://www.wowhead.com/quests/raids/aberrus-the-shadowed-crucible), I have no clue on much it can break the rest of the addon. From my in-game test it has no impact : 
![image](https://user-images.githubusercontent.com/38432216/236625564-ceeb2135-36ee-4279-806b-866a2a3dfea6.png)


> PS: I am sorry about auto format on save who edited some line who does not relate to this MR.

Closes GH-1