### PR TITLE
Multilingual support

### DIFF
--- a/Data.lua
+++ b/Data.lua
@@ -2,43 +2,58 @@ local _, RaidSkipper = ...
 
 RaidSkipper.raid_skip_quests = {
     {
-        name = "Warlords of Draenor",
+        name = EXPANSION_NAME5,
         raids = {
-            { name = "Blackrock Foundary", instanceId = 1205,  mythicId = 37031, heroicId = 37030, normalId = 37029 },
-            { name = "Hellfire Citadel Lower", instanceId = 1448, mythicId = 39501, heroicId = 39500, normalId = 39499 },
-            { name = "Hellfire Citadel Upper", instanceId = 1448, mythicId = 39505, heroicId = 39504, normalId = 39502 }
+			--Blackrock Foundary
+            { instanceId = 1205,  mythicId = 37031, heroicId = 37030, normalId = 37029 },
+			--Hellfire Citadel Lower
+            { instanceId = 1448, mythicId = 39501, heroicId = 39500, normalId = 39499 },
+			--Hellfire Citadel Upper
+            { instanceId = 1448, mythicId = 39505, heroicId = 39504, normalId = 39502 }
         }
     },
     {
-        name = "Legion",
+        name = EXPANSION_NAME6,
         raids = {
-            { name = "The Emerald Nightmare", instanceId = 1520, mythicId = 44285, heroicId = 44284, normalId = 44283 },
-            { name = "The Nighthold", instanceId = 1530, mythicId = 45383, heroicId = 45382, normalId = 45381 },
-            { name = "Tomb of Sargeras", instanceId = 1676, mythicId = 47727, heroicId = 47726, normalId = 47725 },
-            { name = "Burning Throne Lower", instanceId = 1712, mythicId = 49076, heroicId = 49075, normalId = 49032 },
-            { name = "Burning Throne Upper", instanceId = 1712, mythicId = 49135, heroicId = 49134, normalId = 49133 }
+			--The Emerald Nightmare
+            { instanceId = 1520, mythicId = 44285, heroicId = 44284, normalId = 44283 },
+			--The Nighthold
+            { instanceId = 1530, mythicId = 45383, heroicId = 45382, normalId = 45381 },
+            --Tomb of Sargeras
+			{ instanceId = 1676, mythicId = 47727, heroicId = 47726, normalId = 47725 },
+            --Burning Throne Lower
+			{ instanceId = 1712, mythicId = 49076, heroicId = 49075, normalId = 49032 },
+			--Burning Throne Upper
+            { instanceId = 1712, mythicId = 49135, heroicId = 49134, normalId = 49133 }
         }
     },
     {
-        name = "Battle for Azeroth",
+        name = EXPANSION_NAME7,
         raids = {
-            { name = "Battle of Dazar'alor", instanceId = 2070, achievementId = 13314, mythicId = 316476 },
-            { name = "Ny'alotha, the Waking City", instanceId = 2217, mythicId = 58375, heroicId = 58374, normalId = 58373 }
+            --Battle of Dazar'alor
+			{ instanceId = 2070, achievementId = 13314, mythicId = 316476 },
+            --Ny'alotha, the Waking City
+			{ instanceId = 2217, mythicId = 58375, heroicId = 58374, normalId = 58373 }
         }
     },
     {
-        name = "Shadowlands",
+        name = EXPANSION_NAME8,
         raids = {
-            { name = "Castle Nathria", instanceId = 2296, mythicId = 62056, heroicId = 62055, normalId = 62054 },
-            { name = "Sanctum of Domination", instanceId = 2450, mythicId = 64599, heroicId = 64598, normalId = 64597 },
-            { name = "Sepulcher of the First Ones", instanceId = 2481, mythicId = 65762, heroicId = 65763, normalId = 65764 }
+			--Castle Nathria
+            { instanceId = 2296, mythicId = 62056, heroicId = 62055, normalId = 62054 },
+            --Sanctum of Domination
+			{ instanceId = 2450, mythicId = 64599, heroicId = 64598, normalId = 64597 },
+            --Sepulcher of the First Ones
+			{ instanceId = 2481, mythicId = 65762, heroicId = 65763, normalId = 65764 }
         }
     },
     {
-        name = "Dragonflight",
+        name = EXPANSION_NAME9,
         raids = {
-            { name = "Vault of the Incarnates", instanceId = 14030, mythicId = 71020, heroicId = 71019, normalId = 71018 },
-            { name = "Aberrus, the Shadowed Crucible", instanceId = 14663, mythicId = 76086, heroicId = 76085, normalId = 76083 }
+			--Vault of the Incarnates
+            { instanceId = 2522, mythicId = 71020, heroicId = 71019, normalId = 71018 },
+			--"Aberrus, the Shadowed Crucible"
+			{ instanceId = 2569, mythicId = 76086, heroicId = 76085, normalId = 76083 }
         }
     }
 }

--- a/RaidSkipper.lua
+++ b/RaidSkipper.lua
@@ -3,6 +3,8 @@
 ------------------------------------------------------------
 
 local _, RaidSkipper = ...
+local GetRealZoneText = GetRealZoneText
+
 addon_name = "RaidSkipper"
 
 RaidSkipper.AceAddon = LibStub("AceAddon-3.0"):NewAddon("RaidSkipper", "AceConsole-3.0", "AceEvent-3.0")
@@ -14,9 +16,9 @@ RaidSkipper.Print = function(self, text) RaidSkipper.AceAddon:Print(text) end
 
 RaidSkipper.TextColor = function(color, msg)
     local colors = {
-        ["complete"] = "ff00ff00",
-        ["incomplete"] = "ffff0000",
-        ["inprogress"] = "ff00ffff",
+        [COMPLETE] = "ff00ff00",
+        [INCOMPLETE] = "ffff0000",
+        [IN_PROGRESS] = "ff00ffff",
         ["yellow"] = "ffffff00",
         ["red"] = "ffff0000",
         ["green"] = "ff00ff00",
@@ -58,46 +60,46 @@ end
 local function ShowQuestInfo(id, difficulty)
     if (IsQuestComplete(id)) then
         -- Player has completed this quest
-        return RaidSkipper.TextColor("complete", difficulty)
+        return RaidSkipper.TextColor(COMPLETE, difficulty)
     elseif (IsQuestInQuestLog(id)) then
         -- Player has this quest in their quest log
-        return RaidSkipper.TextColor("inprogress", difficulty .. " " .. ShowQuestProgress(id))
+        return RaidSkipper.TextColor(IN_PROGRESS, difficulty .. " " .. ShowQuestProgress(id))
     else
         -- Player has not completed this quest does not have quest in the quest log
-        return RaidSkipper.TextColor("incomplete", difficulty)
+        return RaidSkipper.TextColor(INCOMPLETE, difficulty)
     end
 end
 
 local function ShowAchievementInfo(id)
     if (IsAchievementComplete(id)) then
         -- Player has completed achievement
-        RaidSkipper:Print("completed")
+        RaidSkipper:Print(COMPLETE)
     else
-        RaidSkipper:Print("not completed")
+        RaidSkipper:Print(INCOMPLETE)
     end
 end
 
 local function ShowRaidSkip(raid)
-    local line = "  " .. raid.name .. ": "
+    local line = "  " .. GetRealZoneText(raid.instanceId) .. ": "
 
     -- Battle of Dazar'alor uses an Achievement, not quests
     if raid.instanceId == 2070 then
         local completed = IsAchievementComplete(raid.achievementId)
         if completed then
-            line = line .. RaidSkipper.TextColor("complete", "completed")
+            line = line .. RaidSkipper.TextColor(COMPLETE, COMPLETE)
         else
-            line = line .. RaidSkipper.TextColor("incomplete", "not completed")
+            line = line .. RaidSkipper.TextColor(INCOMPLETE, INCOMPLETE)
         end
     else
         -- Mythic
-        line = line .. ShowQuestInfo(raid.mythicId, "Mythic")
+        line = line .. ShowQuestInfo(raid.mythicId, PLAYER_DIFFICULTY6)
         
         -- Heroic, if Mythic is complete Heroic and Normal can be skipped
         if (not IsQuestComplete(raid.mythicId) and raid.heroicId ~= nil) then
-            line = line .. " " .. ShowQuestInfo(raid.heroicId, "Heroic")
+            line = line .. " " .. ShowQuestInfo(raid.heroicId, PLAYER_DIFFICULTY2)
             -- Normal, if Heroic is complete Normal can be skipped
             if (not IsQuestComplete(raid.heroicId) and raid.normalId ~= nil) then
-                line = line .. " " .. ShowQuestInfo(raid.normalId, "Normal")
+                line = line .. " " .. ShowQuestInfo(raid.normalId, PLAYER_DIFFICULTY1)
             end
         end
         
@@ -125,7 +127,7 @@ local function ShowExpansions()
 end
 
 local function ShowKey()
-    Print("Key: " .. TextColor("blue", "In progress") .. " " .. TextColor("green", "Completed") .. " " .. TextColor("red", "Not completed"))
+    Print("Key: " .. TextColor("blue", IN_PROGRESS) .. " " .. TextColor("green", COMPLETE) .. " " .. TextColor("red", INCOMPLETE))
     Print("Use '/rs help' to display more help")
 end
 
@@ -217,9 +219,9 @@ function IsQuestCompleteHandler(args)
 
     if arg1 then
         if IsQuestComplete(arg1) then
-            RaidSkipper:Print("completed")
+            RaidSkipper:Print(COMPLETE)
         else
-            RaidSkipper:Print("not completed")
+            RaidSkipper:Print(INCOMPLETE)
         end
     end
 end


### PR DESCRIPTION
use GetRealZoneText and globalstring to localed directly.
* remove names table, use GetRealZoneText() by instanceID to get localed raid names.
* use [globalsting](https://www.townlong-yak.com/framexml/live/GlobalStrings.lua) to translate strings by blizzard's locale.
* check [instanceID](https://wowpedia.fandom.com/wiki/InstanceID).